### PR TITLE
Example2: use PROGRAMFILES64

### DIFF
--- a/Examples/Example2.hs
+++ b/Examples/Example2.hs
@@ -23,7 +23,7 @@ example2 = do
     outFile "example$Ex.exe"
 
     -- The default installation directory
-    installDir "$PROGRAMFILES/Example2"
+    installDir "$PROGRAMFILES64/Example2"
 
     -- Registry key to check for directory (so if you install again, it will 
     -- overwrite the old one automatically)


### PR DESCRIPTION
Arguably, 64bit should be the default now.

I was bitten by this, following Example2 (which is great btw).