### PR TITLE
Add Unicode installer option (global)

### DIFF
--- a/Development/NSIS.hs
+++ b/Development/NSIS.hs
@@ -68,7 +68,8 @@ module Development.NSIS
     -- ** Global installer options
     name, outFile, installDir, setCompressor,
     installIcon, uninstallIcon, headerImage,
-    installDirRegKey, allowRootDirInstall, caption, showInstDetails, showUninstDetails,
+    installDirRegKey, allowRootDirInstall, caption,
+    showInstDetails, showUninstDetails, unicode,
     -- ** Sections
     SectionId, section, sectionGroup, newSectionId,
     sectionSetText, sectionGetText, sectionSet, sectionGet,

--- a/Development/NSIS/Show.hs
+++ b/Development/NSIS/Show.hs
@@ -60,6 +60,7 @@ isGlobal x = case x of
     ShowInstDetails{} -> True
     ShowUninstDetails{} -> True
     Caption{} -> True
+    Unicode{} -> True
     _ -> False
 
 isSection :: NSIS -> Bool
@@ -111,6 +112,7 @@ out fs (Plugin a b cs) = [unwords $ (a ++ "::" ++ b) : map show cs]
 out fs (AddPluginDir a) = [unwords ["!addplugindir",show a]]
 out fs (FindWindow a b c d e) = [unwords $ "FindWindow" : show a : map show ([b,c] ++ maybeToList d ++ maybeToList e)]
 out fs (SendMessage a b c d e f) = [unwords $ "SendMessage" : show a : show b : show c : show d : show e : ["/TIMEOUT=" ++ show x | Just x <- [f]]]
+out fs (Unicode x) = ["Unicode " ++ if x then "true" else "false"]
 
 out fs x = [show x]
 

--- a/Development/NSIS/Sugar.hs
+++ b/Development/NSIS/Sugar.hs
@@ -933,6 +933,8 @@ showInstDetails = emit . ShowInstDetails
 showUninstDetails :: Visibility -> Action ()
 showUninstDetails = emit . ShowUninstDetails
 
+unicode :: Bool -> Action ()
+unicode = emit . Unicode
 
 -- | The type of a file handle, created by 'fileOpen'.
 data FileHandle deriving Typeable

--- a/Development/NSIS/Type.hs
+++ b/Development/NSIS/Type.hs
@@ -121,6 +121,7 @@ data NSIS
     | Caption Val
     | ShowInstDetails Visibility
     | ShowUninstDetails Visibility
+    | Unicode Bool
     | SetDetailsPrint DetailsPrint
     | DetailPrint Val
     | Plugin String String [Val]


### PR DESCRIPTION
Give users the option to make a unicode installer. By default it's disabled
because it's incompatible with older versions of Windows (see
http://nsis.sourceforge.net/Docs/Chapter1.html#intro-unicode). The option itself
is documented at http://nsis.sourceforge.net/Docs/Chapter4.html#aunicodetarget.