### PR TITLE
Add unsafeInject and unsafeInjectGlobal

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for NSIS
 
+    #10, add unicode function
 0.3
     Make strCheck take a message
     Add a plugin for helping with radio button

--- a/Development/NSIS.hs
+++ b/Development/NSIS.hs
@@ -80,6 +80,8 @@ module Development.NSIS
     -- ** Section commands
     file, alwaysNonFatal, writeUninstaller, alert, setOutPath, messageBox, requestExecutionLevel,
     hideProgress, detailPrint, setDetailsPrint,
+    -- * Escape hatch
+    injectLiteral, injectGlobalLiteral,
     -- * Settings
     Compressor(..), HKEY(..), MessageBoxType(..), Attrib(..), Page(..), Level(..), Visibility(..),
     FileMode(..), SectionFlag(..), ShowWindow(..), FinishOptions(..), DetailsPrint(..)

--- a/Development/NSIS.hs
+++ b/Development/NSIS.hs
@@ -81,7 +81,7 @@ module Development.NSIS
     file, alwaysNonFatal, writeUninstaller, alert, setOutPath, messageBox, requestExecutionLevel,
     hideProgress, detailPrint, setDetailsPrint,
     -- * Escape hatch
-    injectLiteral, injectGlobalLiteral,
+    unsafeInject, unsafeInjectGlobal,
     -- * Settings
     Compressor(..), HKEY(..), MessageBoxType(..), Attrib(..), Page(..), Level(..), Visibility(..),
     FileMode(..), SectionFlag(..), ShowWindow(..), FinishOptions(..), DetailsPrint(..)
@@ -95,12 +95,18 @@ import Development.NSIS.Library
 
 
 -- | Create the contents of an NSIS script from an installer specification.
+--
+-- Beware, 'unsafeInject' and 'unsafeInjectGlobal' may break 'nsis'. The
+-- optimizer relies on invariants that may not hold when arbitrary lines are
+-- injected. Consider using 'nsisNoOptimise' if problems arise.
 nsis :: Action a -> String
 nsis = unlines . showNSIS . optimise . runAction . void
 
 
--- | Like 'nsis', but don't try and optimise the resulting NSIS script. Useful
---   to figure out how the underlying installer works, or if you believe the
---   optimisations are introducing bugs (but please do report any such bugs!).
+-- | Like 'nsis', but don't try and optimise the resulting NSIS script.
+--
+-- Useful to figure out how the underlying installer works, or if you believe
+-- the optimisations are introducing bugs. Please do report any such bugs,
+-- especially if you aren't using 'unsafeInject' or 'unsafeInjectGlobal'!
 nsisNoOptimise :: Action a -> String
 nsisNoOptimise = unlines . showNSIS . runAction . void

--- a/Development/NSIS/Show.hs
+++ b/Development/NSIS/Show.hs
@@ -60,8 +60,7 @@ isGlobal x = case x of
     ShowInstDetails{} -> True
     ShowUninstDetails{} -> True
     Caption{} -> True
-    Unicode{} -> True
-    InjectGlobalLiteral{} -> True
+    UnsafeInjectGlobal{} -> True
     _ -> False
 
 isSection :: NSIS -> Bool
@@ -114,8 +113,8 @@ out fs (AddPluginDir a) = [unwords ["!addplugindir",show a]]
 out fs (FindWindow a b c d e) = [unwords $ "FindWindow" : show a : map show ([b,c] ++ maybeToList d ++ maybeToList e)]
 out fs (SendMessage a b c d e f) = [unwords $ "SendMessage" : show a : show b : show c : show d : show e : ["/TIMEOUT=" ++ show x | Just x <- [f]]]
 out fs (Unicode x) = ["Unicode " ++ if x then "true" else "false"]
-out fs (InjectLiteral x) = [x]
-out fs (InjectGlobalLiteral x) = [x]
+out fs (UnsafeInject x) = [x]
+out fs (UnsafeInjectGlobal x) = [x]
 
 out fs x = [show x]
 

--- a/Development/NSIS/Show.hs
+++ b/Development/NSIS/Show.hs
@@ -61,6 +61,7 @@ isGlobal x = case x of
     ShowUninstDetails{} -> True
     Caption{} -> True
     Unicode{} -> True
+    InjectGlobalLiteral{} -> True
     _ -> False
 
 isSection :: NSIS -> Bool
@@ -113,6 +114,8 @@ out fs (AddPluginDir a) = [unwords ["!addplugindir",show a]]
 out fs (FindWindow a b c d e) = [unwords $ "FindWindow" : show a : map show ([b,c] ++ maybeToList d ++ maybeToList e)]
 out fs (SendMessage a b c d e f) = [unwords $ "SendMessage" : show a : show b : show c : show d : show e : ["/TIMEOUT=" ++ show x | Just x <- [f]]]
 out fs (Unicode x) = ["Unicode " ++ if x then "true" else "false"]
+out fs (InjectLiteral x) = [x]
+out fs (InjectGlobalLiteral x) = [x]
 
 out fs x = [show x]
 

--- a/Development/NSIS/Sugar.hs
+++ b/Development/NSIS/Sugar.hs
@@ -1154,3 +1154,9 @@ sendMessage as a b c d = do
 
 abort :: Exp String -> Action ()
 abort = emit1 Abort
+
+injectLiteral :: String -> Action ()
+injectLiteral = emit . InjectLiteral
+
+injectGlobalLiteral :: String -> Action ()
+injectGlobalLiteral = emit . InjectGlobalLiteral

--- a/Development/NSIS/Sugar.hs
+++ b/Development/NSIS/Sugar.hs
@@ -1155,8 +1155,10 @@ sendMessage as a b c d = do
 abort :: Exp String -> Action ()
 abort = emit1 Abort
 
-injectLiteral :: String -> Action ()
-injectLiteral = emit . InjectLiteral
+-- | Inject arbitrary text into a non-global section of the script.
+unsafeInject :: String -> Action ()
+unsafeInject = emit . UnsafeInject
 
-injectGlobalLiteral :: String -> Action ()
-injectGlobalLiteral = emit . InjectGlobalLiteral
+-- | Inject arbitrary text into the script's global header section.
+unsafeInjectGlobal :: String -> Action ()
+unsafeInjectGlobal = emit . UnsafeInjectGlobal

--- a/Development/NSIS/Sugar.hs
+++ b/Development/NSIS/Sugar.hs
@@ -933,6 +933,7 @@ showInstDetails = emit . ShowInstDetails
 showUninstDetails :: Visibility -> Action ()
 showUninstDetails = emit . ShowUninstDetails
 
+-- | Note: Requires NSIS 3.0
 unicode :: Bool -> Action ()
 unicode = emit . Unicode
 

--- a/Development/NSIS/Type.hs
+++ b/Development/NSIS/Type.hs
@@ -130,6 +130,10 @@ data NSIS
     | GetDlgItem Var Val Val
     | SendMessage Val Val Val Val Var (Maybe Int)
     | Abort Val
+
+      -- Escape hatch
+    | InjectLiteral String
+    | InjectGlobalLiteral String
       deriving (Data,Typeable,Show)
 
 -- | Value to use with 'setDetailsPrint'.

--- a/Development/NSIS/Type.hs
+++ b/Development/NSIS/Type.hs
@@ -132,8 +132,8 @@ data NSIS
     | Abort Val
 
       -- Escape hatch
-    | InjectLiteral String
-    | InjectGlobalLiteral String
+    | UnsafeInject String
+    | UnsafeInjectGlobal String
       deriving (Data,Typeable,Show)
 
 -- | Value to use with 'setDetailsPrint'.

--- a/Examples/Example2.hs
+++ b/Examples/Example2.hs
@@ -32,6 +32,9 @@ example2 = do
     -- Request application privileges for Windows Vista
     requestExecutionLevel Admin
 
+    -- Inject a literal setting that's not currently supported by the DSL
+    injectGlobalLiteral "# ignore me (could be an injected literal)"
+
     ----------------------------------
 
     -- Pages
@@ -53,6 +56,9 @@ example2 = do
 
         -- Put file there
         file [] "Examples/Example$Ex.hs"
+
+        -- Inject a non-global literal setting
+        injectLiteral "# ignore me (could be an injected literal)"
 
         -- Write the installation path into the registry
         writeRegStr HKLM "SOFTWARE/NSIS_Example2" "Install_Dir" "$INSTDIR"

--- a/Examples/Example2.hs
+++ b/Examples/Example2.hs
@@ -33,7 +33,7 @@ example2 = do
     requestExecutionLevel Admin
 
     -- Inject a literal setting that's not currently supported by the DSL
-    injectGlobalLiteral "# ignore me (could be an injected literal)"
+    unsafeInjectGlobal "# ignore me (could be an injected literal)"
 
     ----------------------------------
 
@@ -58,7 +58,7 @@ example2 = do
         file [] "Examples/Example$Ex.hs"
 
         -- Inject a non-global literal setting
-        injectLiteral "# ignore me (could be an injected literal)"
+        unsafeInject "# ignore me (could be an injected literal)"
 
         -- Write the installation path into the registry
         writeRegStr HKLM "SOFTWARE/NSIS_Example2" "Install_Dir" "$INSTDIR"


### PR DESCRIPTION
Escape hatch so users can inject arbitrary strings into the nsi script. Useful
in cases where the DSL doesn't yet support an NSIS feature, e.g. the new Unicode
option (see #10).

This is a potential solution to issue #7.