### PR TITLE
Add support for WriteRegMultiStr

### DIFF
--- a/src/Development/NSIS.hs
+++ b/src/Development/NSIS.hs
@@ -54,7 +54,7 @@ module Development.NSIS
     getFileTime, fileExists, findEach,
     createDirectory, createShortcut,
     -- ** Registry manipulation
-    readRegStr, deleteRegKey, deleteRegValue, writeRegStr, writeRegExpandStr, writeRegDWORD,
+    readRegStr, deleteRegKey, deleteRegValue, writeRegStr, writeRegExpandStr, writeRegDWORD, writeRegMultiStr,
     -- ** Environment variables
     envVar,
     -- ** Process execution

--- a/src/Development/NSIS/Show.hs
+++ b/src/Development/NSIS/Show.hs
@@ -116,6 +116,7 @@ out fs (SendMessage a b c d e f) = [unwords $ "SendMessage" : show a : show b : 
 out fs (Unicode x) = ["Unicode " ++ if x then "true" else "false"]
 out fs (UnsafeInject x) = [x]
 out fs (UnsafeInjectGlobal x) = [x]
+out fs (WriteRegMultiStr k a b c) = [unwords ["WriteRegMultiStr", "/REGEDIT5", show k, show a, show b, show c]]
 
 out fs x = [show x]
 

--- a/src/Development/NSIS/Sugar.hs
+++ b/src/Development/NSIS/Sugar.hs
@@ -890,6 +890,9 @@ writeRegExpandStr k = emit3 $ WriteRegExpandStr k
 writeRegDWORD :: HKEY -> Exp String -> Exp String -> Exp Int -> Action ()
 writeRegDWORD k = emit3 $ WriteRegDWORD k
 
+writeRegMultiStr :: HKEY -> Exp String -> Exp String -> Exp String -> Action ()
+writeRegMultiStr k = emit3 $ WriteRegMultiStr k
+
 -- | While the action is executing, do not update the progress bar.
 --   Useful for functions which do a large amount of computation, or have loops.
 hideProgress :: Action a -> Action a

--- a/src/Development/NSIS/Type.hs
+++ b/src/Development/NSIS/Type.hs
@@ -103,6 +103,7 @@ data NSIS
     | WriteRegStr HKEY Val Val Val
     | WriteRegExpandStr HKEY Val Val Val
     | WriteRegDWORD HKEY Val Val Val
+    | WriteRegMultiStr HKEY Val Val Val
     | ReadRegStr Var HKEY Val Val
     | DeleteRegKey HKEY Val
     | DeleteRegValue HKEY Val Val


### PR DESCRIPTION
This is a weird design choice on the NSIS side of things, since this keyword always requires the `/REGEDIT5` switch. I dug a bit deeper and stumbled across ([this comment](https://github.com/NSIS-Dev/nsis/blob/691211035c2aaaebe8fbca48ee02d4de93594a52/Source/script.cpp#L4330)), indicating that this might change at some point. However, nothing has changed in that regard in the past 9 years.

I'm not sure what the desired way is to deal with this. NSIS development is slow at best. Should we go for a simpler API and consider a breaking change in the future, or anticipate a change right now?